### PR TITLE
Updating as of 2025-05-15 18:52:27

### DIFF
--- a/push-update.sh
+++ b/push-update.sh
@@ -1,20 +1,36 @@
 #!/bin/bash
 
+#
+# Verify no uncommitted changes
+#
+
+echo `git status` | grep "nothing to commit" > /dev/null 2>&1
+if [ "$?" -ne "0" ]; then
+  # (changes to working tree)
+
+  echo You have uncommitted changes.
+  echo Please commit your changes with a meaningful message before pushing an update.
+  exit 1
+else
+  # (clean repository - nothing to commit)
+  echo "No uncommitted changes, great!"
+fi
+
+#
+# Automatically open new PR
+#
+
 NOW=$(date '+%Y-%m-%d %H:%M:%S')
 NOW_BRANCH="update-$(date '+%Y-%m-%d--%H-%M-%S')"
-
-git add -A
-
-STAGED_CHANGES=$(git status | tail -n +4)
+TITLE="Updating as of $NOW"
+COMMIT_COUNT=`git rev-list --count origin/master..HEAD`
+BODY=$'Changes:\n'
+BODY+=`git log --no-decorate --abbrev-commit -5 --pretty='- (%h) %s'`
 
 git checkout -b "$NOW_BRANCH" &&
 echo &&
 
-git commit -m "Updating as of $NOW
-$STAGED_CHANGES" --allow-empty
-
-echo &&
 git push origin "$NOW_BRANCH" &&
-
 echo &&
-open "https://github.com/keego/bash_aliases/pull/new/$NOW_BRANCH"
+
+open "https://github.com/keego/bash_aliases/compare/master...$NOW_BRANCH?quick_pull=1&title=$TITLE&body=$BODY"


### PR DESCRIPTION
Changes:
- (7a02107) Update push-update.sh to only open new PRs, not auto commit unsaved changes
- (e12c339) Updating as of 2025-05-15 14:04:26
- (5455240) Fix minor typo in push-update.sh
- (52daf9a) Fix history scrolling issues with PS1 and non-printable characters by changing when to interpret backslashes
- (4a25eaf) Fix cdp to properly cd to copied paths that contain spaces